### PR TITLE
Fix hardcoded ANDROID_HOME dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /opt && wget -q https://dl.google.com/android/repository/sdk-tools-linux-
     rm -f android-sdk-tools.zip
 
 # ndk-bundle
-RUN cd /opt/android-sdk-linux/ && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
+RUN cd $ANDROID_HOME && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
     unzip -q ndk-bundle.zip && mv android-ndk-r15c ndk-bundle && chown -R jenkins:jenkins ndk-bundle/
 
 ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools


### PR DESCRIPTION
The ANDROID_HOME dir is hardcoded in the command to install NDK. Changing this to use the env variable.