### PR TITLE
Add commands to install Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+FROM node:8.3
 FROM jenkins/jnlp-slave
+#FROM bitriseio/docker-bitrise-base-alpha:latest
 
 USER root
-
-# replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # update the repository sources list
 # and install dependencies
 RUN apt-get update \
     && apt-get install -y curl \
-    && apt-get -y autoclean
+    && apt-get -y autoclean \
+    && rm -rf /var/lib/apt/lists/*
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
@@ -18,6 +18,8 @@ ENV NODE_VERSION 8.3.0
 # install nvm
 # https://github.com/creationix/nvm#install-script
 RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.2/install.sh | bash
+
+SHELL ["/bin/bash", "-c"]
 
 # install node and npm
 RUN source $NVM_DIR/nvm.sh \
@@ -51,8 +53,8 @@ RUN cd /opt && wget -q https://dl.google.com/android/repository/sdk-tools-linux-
     rm -f android-sdk-tools.zip
 
 # ndk-bundle
-RUN cd $ANDROID_HOME && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
-    unzip -q ndk-bundle.zip && mv android-ndk-r15c ndk-bundle && chown -R jenkins:jenkins ndk-bundle/
+#RUN cd $ANDROID_HOME && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
+#    unzip -q ndk-bundle.zip && mv android-ndk-r15c ndk-bundle && chown -R jenkins:jenkins ndk-bundle/
 
 ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 
@@ -104,5 +106,16 @@ RUN apt-get -y purge maven && \
     apt-get -y install maven && \
     mvn --version && \
     rm -rf /var/lib/apt/lists/*
+
+# ------------------------------------------------------
+# --- Install Fastlane
+#RUN gem install fastlane --no-document
+#RUN fastlane --version
+
+# fix HOME root env variables for android emulator plugin...
+#WORKDIR /root
+#ENV HOME /root
+#RUN usermod -d /root jenkins && chown -R jenkins:root /root && \
+#    chown -R jenkins:jenkins $ANDROID_HOME && chmod -R g+w $ANDROID_HOME
 
 CMD bitrise -version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM node:8.3
 FROM jenkins/jnlp-slave
 #FROM bitriseio/docker-bitrise-base-alpha:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM jenkins/jnlp-slave
-#FROM bitriseio/docker-bitrise-base-alpha:latest
 
 USER root
 
@@ -52,8 +51,8 @@ RUN cd /opt && wget -q https://dl.google.com/android/repository/sdk-tools-linux-
     rm -f android-sdk-tools.zip
 
 # ndk-bundle
-#RUN cd $ANDROID_HOME && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
-#    unzip -q ndk-bundle.zip && mv android-ndk-r15c ndk-bundle && chown -R jenkins:jenkins ndk-bundle/
+RUN cd $ANDROID_HOME && wget -q https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O ndk-bundle.zip && \
+    unzip -q ndk-bundle.zip && mv android-ndk-r15c ndk-bundle && chown -R jenkins:jenkins ndk-bundle/
 
 ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 
@@ -105,16 +104,5 @@ RUN apt-get -y purge maven && \
     apt-get -y install maven && \
     mvn --version && \
     rm -rf /var/lib/apt/lists/*
-
-# ------------------------------------------------------
-# --- Install Fastlane
-#RUN gem install fastlane --no-document
-#RUN fastlane --version
-
-# fix HOME root env variables for android emulator plugin...
-#WORKDIR /root
-#ENV HOME /root
-#RUN usermod -d /root jenkins && chown -R jenkins:root /root && \
-#    chown -R jenkins:jenkins $ANDROID_HOME && chmod -R g+w $ANDROID_HOME
-
+    
 CMD bitrise -version


### PR DESCRIPTION
Chceme na slavech s Androidem buildit i ReactNative appky ale ty potřebují k instalaci závislostí Node. 